### PR TITLE
Updated markdox.js to not double format when custom formatter is provided

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -1,4 +1,3 @@
-
 /*!
  * Module dependencies.
  */
@@ -76,7 +75,8 @@ exports.process = function (files, options, callback) {
         filename: file,
         javadoc: doc
       };
-      var formatedDocfile = options.formatter(formatter.format(docfile));
+      var docFormatter = options.formatter || formatter.format;
+      var formatedDocfile = docFormatter(docfile);
       
       docfiles.push(formatedDocfile);
       callback(err);


### PR DESCRIPTION
Currently when a custom formatter is provided, the docfile is first passed through the default formatter, and then through the custom formatter. 

There might be a benefit in doing this that I'm missing, but I was assuming a formatter would have direct access to the dox output, which it doesn't right now. I also assumed that I could make a direct copy of `formatter.js` to create my own formatter, but this also doesn't work.

PS. Great project. Dox -> Markdown is exactly what I was looking for, and the templates/formatters makes this really flexible.
