### PR TITLE
Pass options object to the parse function to allow overriding of 'compiler' option

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -77,7 +77,7 @@ exports.process = function (files, options, callback) {
         javadoc: doc
       };
       var formatedDocfile = options.formatter(formatter.format(docfile));
-
+      
       docfiles.push(formatedDocfile);
       callback(err);
     });
@@ -87,7 +87,7 @@ exports.process = function (files, options, callback) {
       if (err) {
         throw err;
       }
-
+      
       if (typeof options.output === 'string') {
         fs.writeFile(options.output, output, options.encoding, function(err){
           if (err) {
@@ -99,7 +99,7 @@ exports.process = function (files, options, callback) {
       } else {
         callback(null, output);
       }
-
+      
     });
   });
 };
@@ -122,8 +122,8 @@ exports.parse = function(filepath, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
-  }
-
+  } 
+  
   callback =  callback || function() {};
   options = options || {};
 


### PR DESCRIPTION
Great library! 

It seems that the compiler option is not being used in markdown.js so there's no way to override the default compiler as the docs say. 

This fix passes the options object down into the parse function and then uses the options.compiler to process the data.
