### PR TITLE
gulp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ markdox.process(files, 'output.md', function(){
 
 ```
 
+or with the [gulp plugin](https://github.com/gberger/gulp-markdox)
+
 Quick Start
 ---
   


### PR DESCRIPTION
I wrote a gulp plugin for markdox: https://github.com/gberger/gulp-markdox

This PR adds a link to it in the "Usage" section
