### PR TITLE
pass options to dox

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -140,14 +140,17 @@ exports.parse = function(filepath, options, callback) {
   options = u.defaults(options, {
     encoding: 'utf-8'
     , compiler: compiler
-    , raw: true
+  });
+
+  options.dox = u.defaults(options.dox || {}, {
+    raw: true
   });
 
   fs.readFile(filepath, options.encoding, function(err, data){
 
     data = options.compiler(filepath, data);
 
-    callback(err, dox.parseComments(data, options));
+    callback(err, dox.parseComments(data, options.dox));
   });
 };
 

--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -97,7 +97,7 @@ exports.process = function (files, options, callback) {
       if (err) {
         throw err;
       }
-      
+
       if (typeof options.output === 'string') {
         fs.writeFile(options.output, output, options.encoding, function(err){
           if (err) {
@@ -109,7 +109,7 @@ exports.process = function (files, options, callback) {
       } else {
         callback(null, output);
       }
-      
+
     });
   });
 };
@@ -132,21 +132,22 @@ exports.parse = function(filepath, options, callback) {
   if (typeof options === 'function') {
     callback = options;
     options = {};
-  } 
-  
+  }
+
   callback =  callback || function() {};
   options = options || {};
 
   options = u.defaults(options, {
     encoding: 'utf-8'
     , compiler: compiler
+    , raw: true
   });
 
   fs.readFile(filepath, options.encoding, function(err, data){
 
     data = options.compiler(filepath, data);
 
-    callback(err, dox.parseComments(data, {raw: true}));
+    callback(err, dox.parseComments(data, options));
   });
 };
 


### PR DESCRIPTION
Hi @cbou,

what about passing through options available in the `dox` api from `markdox.process` invocations?
I needed to configure the default dox options so I modified markdox. 

That is what it looks like. Feel free to merge.

regards,
sven