### PR TITLE
restrict ejs dependency to <2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
       "dox": "https://github.com/visionmedia/dox/tarball/master"
     , "commander": ">= 0.6.0"
     , "async": ">= 0.1.18"
-    , "ejs": ">= 0.7.2"
+    , "ejs": ">= 0.7.2 <2.0.0"
     , "underscore": ">= 1.3.3"
     , "coffee-script": ">= 1.3.3"
     , "iced-coffee-script": ">= 1.3.3d"


### PR DESCRIPTION
v2 of EJS has breaking changes: https://github.com/tj/ejs

Fixes https://github.com/cbou/markdox/issues/24