### PR TITLE
markdox doesn't have multiple commands, use 'usage' instead

### DIFF
--- a/bin/markdox
+++ b/bin/markdox
@@ -13,8 +13,8 @@ var program = require('commander')
 
 program
   .version(markdox.version)
-  .option('-o, --output <filepath>', 'specify filepath to output [/path/to/output.md]', String, process.cwd() + '/output.md')
-  .command('markdox [options]... files...');
+  .usage('[options...] files...')
+  .option('-o, --output <filepath>', 'specify filepath to output [/path/to/output.md]', String, process.cwd() + '/output.md');
 
 // examples
 


### PR DESCRIPTION
..otherwise markdox --help shows:

    markdox [options]...] undefined