### PR TITLE
allow URLs to be used in @see tag

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -46,7 +46,7 @@ formatter.format = function (docfile) {
       } else if (tag.type == 'name') {
         tagName = tag.string;
       } else if (tag.type == 'see') {
-        tagSee = tag.local;
+        tagSee = tag.url ? tag.url : tag.local;
       } else if (tag.type == 'version') {
         tagVersion = tag.string;
       } else if (tag.type == 'deprecated') {


### PR DESCRIPTION
dox uses `tag.url` if the `@see` tag has an url (see https://github.com/tj/dox/blob/master/lib/dox.js#L319-L326), this pull request allows to use it (if it's defined) instead of `tag.local`