### PR TITLE
Callback errors, don't throw them.

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -95,13 +95,13 @@ exports.process = function (files, options, callback) {
       return docfiles[file];
     }), options, function(err, output){
       if (err) {
-        throw err;
+        callback(err);
       }
 
       if (typeof options.output === 'string') {
         fs.writeFile(options.output, output, options.encoding, function(err){
           if (err) {
-            throw err;
+            callback(err);
           }
 
           callback(null, output);
@@ -182,7 +182,7 @@ exports.generate = function(docfiles, options, callback) {
 
   fs.readFile(options.template, options.encoding, function(err, data){
     if (err) {
-      throw err;
+      callback(err);
     }
 
     // Remove indentation


### PR DESCRIPTION
Since we have a callback argument, don't throw violent errors.