### PR TITLE
Nuke underscore

### DIFF
--- a/lib/markdox.js
+++ b/lib/markdox.js
@@ -12,7 +12,7 @@ var dox = require('dox')
   , fs = require('fs')
   , util = require('util')
   , ejs = require('ejs')
-  , u = require('underscore')
+  , ul = require('ul')
   , path = require('path');
 
 /*!
@@ -62,7 +62,7 @@ exports.process = function (files, options, callback) {
   callback =  callback || function() {};
   options = options || {};
 
-  options = u.defaults(options, {
+  options = ul.merge(options, {
     output: false
     , encoding: 'utf-8'
     , formatter: formatter
@@ -136,12 +136,12 @@ exports.parse = function(filepath, options, callback) {
   callback =  callback || function() {};
   options = options || {};
 
-  options = u.defaults(options, {
+  options = ul.merge(options, {
     encoding: 'utf-8'
     , compiler: compiler
   });
 
-  options.dox = u.defaults(options.dox || {}, {
+  options.dox = ul.merge(options.dox, {
     raw: true
   });
 
@@ -171,7 +171,7 @@ exports.generate = function(docfiles, options, callback) {
   callback =  callback || function() {};
   options = options || {};
 
-  options = u.defaults(options, {
+  options = ul.merge(options, {
     template: exports.defaultTemplate
     , encoding: 'utf-8'
   });

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     , "commander": ">= 0.6.0"
     , "async": ">= 0.1.18"
     , "ejs": ">= 0.7.2 <2.0.0"
-    , "underscore": ">= 1.3.3"
     , "coffee-script": ">= 1.3.3"
+    , "ul": "2.1.0"
     , "iced-coffee-script": ">= 1.3.3d"
   }
   , "devDependencies": {
@@ -21,12 +21,12 @@
   , "bin": { "markdox": "./bin/markdox" }
   , "keywords": ["documentation", "dox", "markdown"]
   , "repository": {
-    "type": "git", 
+    "type": "git",
     "url": "https://cbou@github.com/cbou/markdox.git"
   }
   , "main": "index"
   , "license": "MIT"
-  , "scripts": { 
+  , "scripts": {
     "documentation": "bin/markdox -o doc/api.md lib/markdox.js"
     , "test": "./node_modules/mocha/bin/mocha test/*-test.js"
     , "examples": "node examples/example.js"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     , "async": ">= 0.1.18"
     , "ejs": ">= 0.7.2 <2.0.0"
     , "coffee-script": ">= 1.3.3"
-    , "ul": "2.1.0"
+    , "ul": "5.0.0"
     , "iced-coffee-script": ">= 1.3.3d"
   }
   , "devDependencies": {

--- a/test/random-order-test.js
+++ b/test/random-order-test.js
@@ -2,19 +2,17 @@ var assert = require('assert');
 var should = require('should');
 var markdox = require('../index');
 var async = require('async');
-var _ = require('underscore');
 
 describe('Markdox', function(){
   it('always render the documentation in the same order', function(done){
     var file = __dirname + '/fixtures/random-order.coffee';
 	var result;
-	
-	async.eachSeries(_.range(50), function(item, callback) {
+	async.eachSeries(new Array(50).join(".").split(".").map(function (c, i) { return i; }), function(item, callback) {
 	    markdox.process(file, function(err, output){
 			if (!result) {
 				result = output;
 			}
-			
+
 			result.should.equal(output);
 			callback();
 	    });


### PR DESCRIPTION
Fixes #32. Replaced `underscore` with [`ul`](https://github.com/IonicaBizau/node-ul). :boom: :bomb: 