### PR TITLE
Remove 0.8 and add 0.12 to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 language: node_js
 node_js:
-  - 0.8
   - 0.10
+  - 0.12


### PR DESCRIPTION
https://github.com/Kuniwak/jsdoctypeparser/ doesn't support node 0.8 anymore, so tests are failing.
Tests pass fine on 0.12 (requires PR #38).