### PR TITLE
Omit asterisks around param/return type if no types are specified.

### DIFF
--- a/templates/template.md.ejs
+++ b/templates/template.md.ejs
@@ -39,13 +39,13 @@
       <? if (comment.paramTags.length > 0) { ?>
         ### Params:
         <? comment.paramTags.forEach(function(paramTag) { ?>
-          * **<?= paramTag.joinedTypes ?>** *<?= paramTag.name ?>* <?= paramTag.description ?><? }) ?>
+          *<? if (paramTag.types.length > 0) { ?> **<?= paramTag.joinedTypes ?>**<? } ?> *<?= paramTag.name ?>* <?= paramTag.description ?><? }) ?>
       <? } ?>
 
       <? if (comment.returnTags.length > 0) { ?>
         ### Return:
         <? comment.returnTags.forEach(function(returnTag) { ?>
-          * **<?= returnTag.joinedTypes ?>** <?= returnTag.description ?>
+          *<? if (returnTag.types.length > 0) { ?> **<?= returnTag.joinedTypes ?>**<? } ?> <?= returnTag.description ?>
         <? }) ?>
       <? } ?>
     <? } ?>


### PR DESCRIPTION
Fixes #42 